### PR TITLE
Add Streamlit web interface and refactor core logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+plotly
+requests
+streamlit

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,56 @@
+from datetime import date, datetime
+import io
+import zipfile
+
+import streamlit as st
+
+from SPREADS import compute_spreads
+
+st.set_page_config(page_title="Spreads eléctricos", layout="wide")
+
+st.markdown(
+    """
+    <style>
+    * {font-family: 'Calibri', sans-serif;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+st.title("Calculadora de Spreads de Precios Eléctricos")
+
+with st.form("spread_form"):
+    col1, col2, col3 = st.columns(3)
+    start_date = col1.date_input("Fecha de inicio", value=date.today())
+    end_date = col2.date_input("Fecha de fin", value=date.today())
+    horas = col3.number_input("Horas", min_value=1, max_value=24, value=6)
+    submitted = st.form_submit_button("Calcular")
+
+if submitted:
+    try:
+        daily_spread, monthly_spread, fig_daily, fig_monthly = compute_spreads(
+            datetime.combine(start_date, datetime.min.time()),
+            datetime.combine(end_date, datetime.min.time()),
+            int(horas),
+        )
+        st.subheader("Spread diario")
+        st.plotly_chart(fig_daily, use_container_width=True)
+
+        st.subheader("Spread mensual")
+        st.plotly_chart(fig_monthly, use_container_width=True)
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr("daily_spread.csv", daily_spread.to_csv(index=False))
+            zf.writestr("monthly_spread.csv", monthly_spread.to_csv(index=False))
+        buffer.seek(0)
+        st.download_button(
+            "Descargar resultados",
+            data=buffer,
+            file_name="spreads.zip",
+            mime="application/zip",
+        )
+    except EnvironmentError as err:
+        st.error(str(err))
+    except Exception as exc:
+        st.error(f"Ocurrió un error: {exc}")


### PR DESCRIPTION
## Summary
- Refactor SPREADS calculations into reusable `compute_spreads` returning dataframes and Plotly figures
- Apply blue color palette and Calibri font to generated figures
- Introduce Streamlit web app with date inputs, interactive plots and results download
- Document dependencies in `requirements.txt`

## Testing
- `python -m py_compile SPREADS.py web_app.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_68ac560392108333bd3b92fc1946576a