### PR TITLE
Load spreads data from local CSV

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 import io
 import zipfile
-import os
 
 import streamlit as st
 
@@ -21,7 +20,6 @@ st.markdown(
 st.title("Calculadora de Spreads de Precios Eléctricos")
 
 with st.form("spread_form"):
-    api_token = st.text_input("Token ESIOS API", type="password")
     col1, col2, col3 = st.columns(3)
     start_date = col1.date_input("Fecha de inicio", value=date.today())
     end_date = col2.date_input("Fecha de fin", value=date.today())
@@ -29,8 +27,6 @@ with st.form("spread_form"):
     submitted = st.form_submit_button("Calcular")
 
 if submitted:
-    if api_token:
-        os.environ["TOKEN"] = api_token
     try:
         daily_spread, monthly_spread, fig_daily, fig_monthly = compute_spreads(
             datetime.combine(start_date, datetime.min.time()),
@@ -54,7 +50,5 @@ if submitted:
             file_name="spreads.zip",
             mime="application/zip",
         )
-    except EnvironmentError as err:
-        st.error(str(err))
     except Exception as exc:
         st.error(f"Ocurrió un error: {exc}")


### PR DESCRIPTION
## Summary
- Read price data from `input.csv` instead of requesting ESIOS API
- Remove API token handling and simplify Streamlit form

## Testing
- `python -m py_compile SPREADS.py web_app.py`
- `python - <<'PY'
from datetime import datetime
from SPREADS import compute_spreads

daily, monthly, _, _ = compute_spreads(datetime(2025,1,1), datetime(2025,1,3), 6)
print(daily.head())
print(monthly.head())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac7abe2d4c8333b4a646f58bd37ec6