### PR TITLE
Rename app to BESS spread and export Excel spreads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 plotly
 streamlit
+openpyxl


### PR DESCRIPTION
## Summary
- Rename app and page title to **BESS spread** with a brief description
- Remove country price difference chart and related calculations
- Provide separate Excel downloads for daily and monthly spreads

## Testing
- ⚠️ `pip install -r requirements.txt` (proxy error prevented installation)
- ✅ `python -m py_compile SPREADS.py web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac934fd8f083338166de041a95b76a